### PR TITLE
Category Controller / RSpec & SetUp requestHelper/sharedExamples/serializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ gem 'puma', '~> 4.1'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
+gem 'active_model_serializers'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.12)
+      actionpack (>= 4.1, < 6.2)
+      activemodel (>= 4.1, < 6.2)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.0.3.5)
       activesupport (= 6.0.3.5)
       globalid (>= 0.3.6)
@@ -61,6 +66,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    case_transform (0.2)
+      activesupport
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     diff-lcs (1.4.4)
@@ -77,6 +84,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.8)
       concurrent-ruby (~> 1.0)
+    jsonapi-renderer (0.2.2)
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -206,6 +214,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   bootsnap (>= 1.4.2)
   byebug
   factory_bot_rails

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class CategoriesController < ApplicationController
+      # POST /categories
+      def create
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -8,7 +8,7 @@ module Api
         new_category = Category.new(category_params)
 
         if new_category.save
-          render json: { data: new_category }, status: :created
+          render json: { data: CategorySerializer.new(new_category) }, status: :created
         else
           render json: { error: 'Failed to create new Category', data: new_category.errors }, status: :bad_request
         end
@@ -16,7 +16,7 @@ module Api
 
       # GET /categories
       def index
-        render json: { data: Caterogy.all }, status: :ok
+        render json: Category.all, each_serializer: CategorySerializer
       end
 
       private

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -14,6 +14,11 @@ module Api
         end
       end
 
+      # GET /categories
+      def index
+        render json: { data: Caterogy.all }, status: :ok
+      end
+
       private
 
       def category_params

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -5,6 +5,19 @@ module Api
     class CategoriesController < ApplicationController
       # POST /categories
       def create
+        new_category = Category.new(category_params)
+
+        if new_category.save
+          render json: { data: new_category }, status: :created
+        else
+          render json: { error: 'Failed to create new Category', data: new_category.errors }, status: :bad_request
+        end
+      end
+
+      private
+
+      def category_params
+        params.require(:category).permit(:name)
       end
     end
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,4 +2,6 @@
 
 class Category < ApplicationRecord
   validates :name, length: { maximum: 255 }, presence: true
+
+  default_scope { order(id: :asc) }
 end

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,0 +1,3 @@
+class CategorySerializer < ActiveModel::Serializer
+  attributes :id
+end

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,3 +1,6 @@
 class CategorySerializer < ActiveModel::Serializer
   attributes :id
+  attributes :name
+  attributes :created_at
+  attributes :updated_at
 end

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CategorySerializer < ActiveModel::Serializer
   attributes :id
   attributes :name

--- a/config/initializers/active_model_serializer.rb
+++ b/config/initializers/active_model_serializer.rb
@@ -1,0 +1,1 @@
+ActiveModel::Serializer.config.adapter = :json

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       # Category
-      resources :categories, only: [:create], controller: 'categories'
+      resources :categories, only: [:index, :create], controller: 'categories'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      # Category
+      resources :categories, only: [:create], controller: 'categories'
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -35,6 +35,8 @@ end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
+
+  config.include RequestHelpers::JsonHelpers, type: :request
 
   # FactoryBot利用
   config.include FactoryBot::Syntax::Methods

--- a/spec/requests/categories_request_spec.rb
+++ b/spec/requests/categories_request_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'Categories', type: :request do
+  describe 'POST /categories' do
+    let(:headers) { { ACCEPT: 'application/json'} }
+    let(:endpoint) { '/api/v1/categories' }
+    let(:request) { post endpoint, headers: headers, as: :json, params: { category: category_params }}
+    
+    let(:category_params) { { name: name }}
+    let(:name) { Faker::Alphanumeric.alpha(number: 10) }
+
+    context 'SUCCESS' do
+      before { request }
+
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: CREATED'
+    end
+
+    context 'SUCCESS on save' do
+      it 'increase total number of category by 1' do
+        expect { request }.to change { Category.count }.by(1)
+      end 
+    end
+
+    context 'ERROR: name not found' do
+      let(:name) { nil }
+      before { request }
+
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: BAD REQUEST'
+    end
+  end
+end

--- a/spec/requests/categories_request_spec.rb
+++ b/spec/requests/categories_request_spec.rb
@@ -33,4 +33,27 @@ RSpec.describe 'Categories', type: :request do
       it_behaves_like 'response status code: BAD REQUEST'
     end
   end
+
+  describe 'GET /categories' do
+    let(:endpoint) { '/api/v1/categories' }
+
+    let!(:first_category) { create(:category) }
+    let!(:second_category) { create(:category) }
+
+    context 'SUCCESS' do
+      before { get endpoint }
+
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: OK'
+      it 'returns two category' do
+        expect(json['categories'].size).to eq 2
+
+        expect(json['categories'][0]['id']).to eq first_category.id
+        expect(json['categories'][0]['name']).to eq first_category.name
+
+        expect(json['categories'][1]['id']).to eq second_category.id
+        expect(json['categories'][1]['name']).to eq second_category.name
+      end
+    end
+  end
 end

--- a/spec/requests/categories_request_spec.rb
+++ b/spec/requests/categories_request_spec.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'Categories', type: :request do
   describe 'POST /categories' do
-    let(:headers) { { ACCEPT: 'application/json'} }
+    let(:headers) { { ACCEPT: 'application/json' } }
     let(:endpoint) { '/api/v1/categories' }
-    let(:request) { post endpoint, headers: headers, as: :json, params: { category: category_params }}
-    
-    let(:category_params) { { name: name }}
+    let(:request) { post endpoint, headers: headers, as: :json, params: { category: category_params } }
+
+    let(:category_params) { { name: name } }
     let(:name) { Faker::Alphanumeric.alpha(number: 10) }
 
     context 'SUCCESS' do
@@ -19,11 +21,12 @@ RSpec.describe 'Categories', type: :request do
     context 'SUCCESS on save' do
       it 'increase total number of category by 1' do
         expect { request }.to change { Category.count }.by(1)
-      end 
+      end
     end
 
     context 'ERROR: name not found' do
       let(:name) { nil }
+
       before { request }
 
       it_behaves_like 'API returns json'

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,7 @@
+module RequestHelpers
+  module JsonHelpers
+    def json
+      JSON.parse(response.body)
+    end
+  end
+end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RequestHelpers
   module JsonHelpers
     def json

--- a/spec/support/shared_examples/request_examples.rb
+++ b/spec/support/shared_examples/request_examples.rb
@@ -1,25 +1,25 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples 'API returns json' do
   specify { expect(response.content_type).to eq('application/json; charset=utf-8') }
 end
 
 RSpec.shared_examples 'response status code: OK' do
-  specify { expect(response).to have_http_status(:ok)}
+  specify { expect(response).to have_http_status(:ok) }
 end
 
 RSpec.shared_examples 'response status code: CREATED' do
-  specify { expect(response).to have_http_status(:created)}
+  specify { expect(response).to have_http_status(:created) }
 end
 
 RSpec.shared_examples 'response status code: BAD REQUEST' do
-  specify { expect(response).to have_http_status(:bad_request)}
+  specify { expect(response).to have_http_status(:bad_request) }
 end
 
 RSpec.shared_examples 'response status code: NOT FOUND' do
-  specify { expect(response).to have_http_status(:not_found)}
+  specify { expect(response).to have_http_status(:not_found) }
 end
-
 
 RSpec.shared_examples 'response status code: INTERNAL SERVER ERROR' do
-  specify { expect(response).to have_http_status(:internal_server_error)}
+  specify { expect(response).to have_http_status(:internal_server_error) }
 end
-    

--- a/spec/support/shared_examples/request_examples.rb
+++ b/spec/support/shared_examples/request_examples.rb
@@ -1,0 +1,25 @@
+RSpec.shared_examples 'API returns json' do
+  specify { expect(response.content_type).to eq('application/json; charset=utf-8') }
+end
+
+RSpec.shared_examples 'response status code: OK' do
+  specify { expect(response).to have_http_status(:ok)}
+end
+
+RSpec.shared_examples 'response status code: CREATED' do
+  specify { expect(response).to have_http_status(:created)}
+end
+
+RSpec.shared_examples 'response status code: BAD REQUEST' do
+  specify { expect(response).to have_http_status(:bad_request)}
+end
+
+RSpec.shared_examples 'response status code: NOT FOUND' do
+  specify { expect(response).to have_http_status(:not_found)}
+end
+
+
+RSpec.shared_examples 'response status code: INTERNAL SERVER ERROR' do
+  specify { expect(response).to have_http_status(:internal_server_error)}
+end
+    


### PR DESCRIPTION
## 概要
CategoryController / Test を作成した
* `POST /categories`
パラメータ: { name: name }
* `GET /categories`

以下の様々な設定をしてます（PR分けるべきでした...）
* RequestHelpers::JsonHelper
* Shared examples
* active_model_serializers

## 詳細（主に技術的変更点）
### RequestHelpers::JsonHelper
JSON.parse を support にまとめる．
[参考](https://matthewlehner.net/rails-api-testing-guidelines)
```ruby
# spec/support/request_helpers.rb
module RequestHelpers
  module JsonHelpers
    def json
      JSON.parse(response.body)
    end
  end
end
```
```ruby
# spec/rails_helper.rb
RSpec.configure do |config|
  # ...

  config.include RequestHelpers::JsonHelpers, type: :request

  # ...
```

使用例： from 公式ドキュメント

before
```ruby
# spec/requests/api/v1/messages_spec.rb
describe "Messages API" do
  it 'sends a list of messages' do
    FactoryGirl.create_list(:message, 10)

    get '/api/v1/messages'

    json = JSON.parse(response.body)

    # test for the 200 status-code
    expect(response).to be_success

    # check to make sure the right amount of messages are returned
    expect(json['messages'].length).to eq(10)
  end
end
```

after
```ruby
# spec/requests/api/v1/messages_spec.rb
describe "Messages API" do
  it 'retrieves a specific message' do
    message = FactoryGirl.create(:message)
    get "/api/v1/messages/#{message.id}"

    # test for the 200 status-code
    expect(response).to be_success

    # check that the message attributes are the same.
    expect(json['content']).to eq(message.content)

    # ensure that private attributes aren't serialized
    expect(json['private_attr']).to eq(nil)
  end
end
```
### Shared examples
[参考](https://relishapp.com/rspec/rspec-core/v/3-3/docs/example-groups/shared-examples)
```ruby
RSpec.shared_examples 'API returns json' do
  specify { expect(response.content_type).to eq('application/json; charset=utf-8') }
end

RSpec.shared_examples 'response status code: OK' do
  specify { expect(response).to have_http_status(:ok) }
end

# ...
```

### active_model_serializers
[参考](https://github.com/rails-api/active_model_serializers/blob/0-10-stable/docs/general/adapters.md#adapters)
[Active Model Serializer をざっくり使ってみた](https://qiita.com/kazusa-s/items/35d849cfd2c485cb1705)

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）

## 保留した項目・TODOリスト

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）

