### PR TITLE
LINE accessToken を用いて認証を行うようにした

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -39,4 +39,5 @@ jobs:
           MYSQL_PASSWORD: root
           RAILS_ENV: github_action
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          AUTHORIZATION_URL: ${{ secrets.AUTHORIZATION_URL }}
         run: bundle exec rspec --require rails_helper

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@
 */.DS_Store
 
 /vendor
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ gem 'puma', '~> 4.1'
 
 gem 'active_model_serializers'
 
+# 環境変数取得
+gem 'dotenv-rails'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,10 @@ GEM
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     diff-lcs (1.4.4)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
@@ -217,6 +221,7 @@ DEPENDENCIES
   active_model_serializers
   bootsnap (>= 1.4.2)
   byebug
+  dotenv-rails
   factory_bot_rails
   faker
   listen (~> 3.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,17 @@
 # frozen_string_literal: true
 
+# Verify IdToken from Firebase before any actions within any controllers
 class ApplicationController < ActionController::API
+  before_action :authorize_request
+  skip_before_action :authorize_request, only: [:hello]
+
   def hello
-    render json: { status: 'SUCCESS', data: 'Hello TrainBot' }, status: :ok
+    render json: { status: 'SUCCESS', data: 'Hello WishApiServer' }, status: :ok
+  end
+
+  private
+
+  def authorize_request
+    render json: { errors: ['Not Authenticated'] }, status: :unauthorized unless AuthorizationService.new(request.headers).verify_token
   end
 end

--- a/app/services/authorization_service.rb
+++ b/app/services/authorization_service.rb
@@ -8,7 +8,8 @@ class AuthorizationService
 
   def extract_access_token(headers)
     return headers['LINEAuthorization'] if headers['LINEAuthorization'].present?
-    return ""
+
+    ""
   end
 
   def verify_token
@@ -20,6 +21,7 @@ class AuthorizationService
 
     # check: clientId
     return false if json_response['client_id'] != @client_id
+
     true
   end
 end

--- a/app/services/authorization_service.rb
+++ b/app/services/authorization_service.rb
@@ -7,7 +7,7 @@ class AuthorizationService
   end
 
   def extract_access_token(headers)
-    return headers['LINE_Authorization'] if headers['LINE_Authorization'].present?
+    return headers['LINEAuthorization'] if headers['LINEAuthorization'].present?
     return ""
   end
 
@@ -15,14 +15,10 @@ class AuthorizationService
     require "net/http"
 
     uri = URI.parse(@request_url)
-    response = Net::HTTP.get_response(uri)
-
-    # check: statsuCode
-    return false if response.code != 200
+    response = Net::HTTP.get(uri)
 
     # check: clientId
-    return false if response.body.client_id != @client_id
-
+    return false if response['client_id'] != @client_id
     true
   end
 end

--- a/app/services/authorization_service.rb
+++ b/app/services/authorization_service.rb
@@ -16,9 +16,10 @@ class AuthorizationService
 
     uri = URI.parse(@request_url)
     response = Net::HTTP.get(uri)
+    json_response = JSON.parse(response)
 
     # check: clientId
-    return false if response['client_id'] != @client_id
+    return false if json_response['client_id'] != @client_id
     true
   end
 end

--- a/app/services/authorization_service.rb
+++ b/app/services/authorization_service.rb
@@ -2,8 +2,13 @@
 
 class AuthorizationService
   def initialize(headers = {})
-    @request_url = ENV['AUTHORIZATION_URL'] + headers['LINE_Authorization']
+    @request_url = ENV['AUTHORIZATION_URL'] + extract_access_token(headers)
     @client_id = String(ENV['LINE_CLIENT_ID'])
+  end
+
+  def extract_access_token(headers)
+    return headers['LINE_Authorization'] if headers['LINE_Authorization'].present?
+    return ""
   end
 
   def verify_token

--- a/app/services/authorization_service.rb
+++ b/app/services/authorization_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AuthorizationService
+  def initialize(headers = {})
+    @request_url = ENV['AUTHORIZATION_URL'] + headers['LINE_Authorization']
+    @client_id = String(ENV['LINE_CLIENT_ID'])
+  end
+
+  def verify_token
+    require "net/http"
+
+    uri = URI.parse(@request_url)
+    response = Net::HTTP.get_response(uri)
+
+    # check: statsuCode
+    return false if response.code != 200
+
+    # check: clientId
+    return false if response.body.client_id != @client_id
+
+    true
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Category, type: :model do
+  before { skip_token_authorization }
+
   describe 'validation: name' do
     it { is_expected.to validate_length_of(:name).is_at_most(255) }
     it { is_expected.to validate_presence_of(:name) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,7 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
+  config.include SkipTokenAuthorization # skip auth in test
   config.include RequestHelpers::JsonHelpers, type: :request
 
   # FactoryBot利用

--- a/spec/requests/categories_request_spec.rb
+++ b/spec/requests/categories_request_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Categories', type: :request do
+  before { skip_token_authorization }
+
   describe 'POST /categories' do
     let(:headers) { { ACCEPT: 'application/json' } }
     let(:endpoint) { '/api/v1/categories' }

--- a/spec/support/skip_token_authorization.rb
+++ b/spec/support/skip_token_authorization.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SkipTokenAuthorization
+  def skip_token_authorization
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(AuthorizationService).to receive(:verify_token).and_return(true)
+    # rubocop:enable RSpec/AnyInstance
+  end
+end


### PR DESCRIPTION
## 概要
LINE accessToken を用いて認証を行うようにした．
アプリ側で記載しているように 認証を強化する必要あり．

→ テストで認証を skip する処理も実装
## 詳細（主に技術的変更点）

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）

## 保留した項目・TODOリスト

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）

