### PR TITLE
endpoint #POST /users#create

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class UsersController < ApplicationController
+      # POST /users
+      # return Userinfo
+      def create
+        new_user = User.new(user_params)
+
+        if new_user.save
+          render json: { user: UserSerializer.new(new_user) }, status: :created
+        else
+          render json: { user: UserSerializer.new(set_user) }, status: :created
+        end
+      end
+
+      private
+
+      def set_user
+        return User.find_by(uid: user_params[:uid])
+      end
+
+      def user_params
+        params.require(:user).permit(:name, :uid)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -7,19 +7,18 @@ module Api
       # return Userinfo
       def create
         new_user = User.new(user_params)
+        user = User.find_by(uid: user_params[:uid])
 
         if new_user.save
           render json: { user: UserSerializer.new(new_user) }, status: :created
-        else
-          render json: { user: UserSerializer.new(set_user) }, status: :created
+        elsif user # 既に作成されている場合
+          render json: { user: UserSerializer.new(user) }, status: :ok
+        else # パラメータでエラーが発生した場合
+          render json: { erorr: 'Faild to create new user', data: new_user.errors }, status: :bad_request
         end
       end
 
       private
-
-      def set_user
-        return User.find_by(uid: user_params[:uid])
-      end
 
       def user_params
         params.require(:user).permit(:name, :uid)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class User < ApplicationRecord
+  validates :name, length: { maximum: 255 }, presence: true
+  validates :uid, length: { maximum: 255 }, presence: true, uniqueness: { case_sensitive: true }
+
+  default_scope { order(id: :asc) }
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UserSerializer < ActiveModel::Serializer
+  attributes :id
+  attributes :name
+  attributes :uid
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      # User
+      resources :users, param: :uid, only: [:create], controller: 'users'
       # Category
       resources :categories, only: [:index, :create], controller: 'categories'
     end

--- a/db/migrate/20210220135206_create_users.rb
+++ b/db/migrate/20210220135206_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+      t.string :name, null: false
+      t.string :uid, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210220222210_add_index_users_uid.rb
+++ b/db/migrate/20210220222210_add_index_users_uid.rb
@@ -1,0 +1,5 @@
+class AddIndexUsersUid < ActiveRecord::Migration[6.0]
+  def change
+    add_index :users, :uid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_15_174252) do
+ActiveRecord::Schema.define(version: 2021_02_20_135206) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "uid", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_20_135206) do
+ActiveRecord::Schema.define(version: 2021_02_20_222210) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "name", null: false
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2021_02_20_135206) do
     t.string "uid", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user do
+    name { Faker::Alphanumeric.alpha(number: 10) }
+    uid { Faker::Alphanumeric.unique.alphanumeric(number: 20, min_alpha: 10) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  before { skip_token_authorization }
+
+  describe 'validation: name' do
+    it { is_expected.to validate_length_of(:name).is_at_most(255) }
+    it { is_expected.to validate_presence_of(:name) }
+  end
+
+  describe 'validation: uid' do
+    subject { create(:user) }
+
+    it { is_expected.to validate_presence_of(:uid) }
+    it { is_expected.to validate_length_of(:uid).is_at_most(255) }
+    it { is_expected.to validate_uniqueness_of(:uid) }
+  end
+end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Users', type: :request do
+  before { skip_token_authorization }
+
+  describe 'POST /users' do
+    let(:request) { post '/api/v1/users', headers: { ACCEPT: 'application/json' }, as: :json, params: { user: user_params } }
+
+    let(:user_params) do
+      {
+        name: name,
+        uid: uid
+      }
+    end
+
+    let(:name) { Faker::Alphanumeric.alpha(number: 10) }
+    let(:uid) { Faker::Alphanumeric.alpha(number: 10) }
+
+    context 'SUCCESS: createUser' do
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: CREATED'
+      it 'increase total number of user 1' do
+        expect { request }.to change { User.count }.by(1)
+      end
+
+      it 'returns: created user' do
+        request
+        expect(json['user']).to include(
+          {
+            'name' => name,
+            'uid' => uid
+          }
+        )
+      end
+    end
+
+    context 'SUCCESS: already created user' do
+      let!(:user) { create(:user, name: name, uid: uid) }
+
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: OK'
+      it 'NOT: increase total number of user' do
+        expect { request }.to change { User.count }.by(0)
+      end
+
+      it 'returns: created user' do
+        request
+        expect(json['user']).to include(
+          {
+            'name' => user.name,
+            'uid' => user.uid
+          }
+        )
+      end
+    end
+
+    context 'ERROR: not name in params' do
+      let(:name) { nil }
+
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: BAD REQUEST'
+    end
+
+    context 'ERROR: not uid in params' do
+      let(:uid) { nil }
+
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: BAD REQUEST'
+    end
+  end
+end

--- a/spec/support/shared_examples/request_examples.rb
+++ b/spec/support/shared_examples/request_examples.rb
@@ -1,25 +1,43 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'API returns json' do
-  specify { expect(response.content_type).to eq('application/json; charset=utf-8') }
+  specify do
+    request
+    expect(response.content_type).to eq('application/json; charset=utf-8')
+  end
 end
 
 RSpec.shared_examples 'response status code: OK' do
-  specify { expect(response).to have_http_status(:ok) }
+  specify do
+    request
+    expect(response).to have_http_status(:ok)
+  end
 end
 
 RSpec.shared_examples 'response status code: CREATED' do
-  specify { expect(response).to have_http_status(:created) }
+  specify do
+    request
+    expect(response).to have_http_status(:created)
+  end
 end
 
 RSpec.shared_examples 'response status code: BAD REQUEST' do
-  specify { expect(response).to have_http_status(:bad_request) }
+  specify do
+    request
+    expect(response).to have_http_status(:bad_request)
+  end
 end
 
 RSpec.shared_examples 'response status code: NOT FOUND' do
-  specify { expect(response).to have_http_status(:not_found) }
+  specify do
+    request
+    expect(response).to have_http_status(:not_found)
+  end
 end
 
 RSpec.shared_examples 'response status code: INTERNAL SERVER ERROR' do
-  specify { expect(response).to have_http_status(:internal_server_error) }
+  specify do
+    request
+    expect(response).to have_http_status(:internal_server_error)
+  end
 end


### PR DESCRIPTION
## 概要
ユーザを作成するエンドポイントを追加
単純な  #create と異なるため要注意
 1 から順番に実行し，失敗した場合に次の処理を行う．
```
1. パラメータを元にユーザを作成する
2. パラメータを元にユーザを検索する
3. パラメータエラー (BadRequest: 500) を返す
```

また `spec/support/shared_examples/request_examples.rb` を修正した
→ `request`をexampleの中で実行することでテストをまとめれるようにした

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）
動作確認済み
- [ ] ユーザのプロフィール画像をアイコンにするかも...？

