### PR TITLE
WishController を作成 /users/:uid/wishes #index #create

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,6 +82,8 @@ RSpec/MultipleExpectations:
   Enabled: false
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
+RSpec/LetSetup:
+  Enabled: false
 
 # Gemfile
 Bundler/OrderedGems:

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -16,7 +16,7 @@ module Api
 
       # GET /categories
       def index
-        render json: Category.all, each_serializer: CategorySerializer
+        render json: Category.all, each_serializer: CategorySerializer, root: 'data'
       end
 
       private

--- a/app/controllers/api/v1/users/wishes_controller.rb
+++ b/app/controllers/api/v1/users/wishes_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Users
+      class WishesController < ApplicationController
+        before_action :set_user, only: %i[index create]
+        before_action :set_category, only: %i[create]
+
+        # GET /users/:uid/wishes?category_id=
+        def index
+          user_wishes_by_category = @user.wishes.where(category_id: params[:category_id])
+          render json: user_wishes_by_category, each_serializer: WishSerializer, root: 'data'
+        end
+
+        # POST /users/:uid/wishes
+        def create
+          new_wish = Wish.new(wish_params.merge({ user: @user, category: @category, status: :wish, deleted: false }))
+
+          if new_wish.save
+            render json: { data: WishSerializer.new(new_wish) }, status: :created
+          else
+            render json: { error: 'Failed to create new Wish', data: new_wish.errors }, status: :bad_request
+          end
+        end
+
+        private
+
+        def set_user
+          @user = User.find_by(uid: params[:uid])
+          render json: { error: 'user not found' }, status: :not_found unless @user
+        end
+
+        def set_category
+          @category = Category.find_by(id: category_params[:category_id])
+          render json: { error: 'category not found' }, status: :not_found unless @category
+        end
+
+        def wish_params
+          params.require(:wish).permit(:name, :star)
+        end
+
+        def category_params
+          params.require(:wish).permit(:category_id)
+        end
+      end
+    end
+  end
+end

--- a/app/models/wish.rb
+++ b/app/models/wish.rb
@@ -15,5 +15,5 @@ class Wish < ApplicationRecord
   }
   validates :status, presence: true
 
-  validates :deleted, inclusion: { in: [true, false] }, presence: true
+  validates :deleted, inclusion: { in: [true, false] }
 end

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class CategorySerializer < ActiveModel::Serializer
-  attributes :id
-  attributes :name
-  attributes :created_at
-  attributes :updated_at
+  attribute :id
+  attribute :name
+  attribute :created_at
+  attribute :updated_at
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UserSerializer < ActiveModel::Serializer
-  attributes :id
-  attributes :name
-  attributes :uid
+  attribute :id
+  attribute :name
+  attribute :uid
 end

--- a/app/serializers/wish_serializer.rb
+++ b/app/serializers/wish_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class WishSerializer < ActiveModel::Serializer
+  attribute :id
+  attribute :user_id
+  attribute :category_id
+  attribute :name
+  attribute :star
+  attribute :status
+  attribute :deleted
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,11 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       # User
-      resources :users, param: :uid, only: [:create], controller: 'users'
+      resources :users, param: :uid, only: [:create], controller: 'users' do
+        member do #users/:uid
+          resources :wishes, only: [:index, :create], controller: 'users/wishes'
+        end
+      end
       # Category
       resources :categories, only: [:index, :create], controller: 'categories'
     end

--- a/spec/factories/wish.rb
+++ b/spec/factories/wish.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :wish do
+    user { association(:user) }
+    category { association(:category) }
+    name { Faker::Alphanumeric.alpha(number: 10) }
+    star { Faker::Number.within(range: 1..5) }
+    status { 'wish' }
+    deleted { false }
+  end
+end

--- a/spec/models/wish_spec.rb
+++ b/spec/models/wish_spec.rb
@@ -22,10 +22,4 @@ RSpec.describe Wish, type: :model do
     it { is_expected.to validate_presence_of(:status) }
     it { is_expected.to define_enum_for(:status).with_values(%i[wish bougth]) }
   end
-
-  describe 'validate: deleted' do
-    it { is_expected.to validate_presence_of(:deleted) }
-    # boolean columns will automatically convert non-boolean values to boolean ones
-    # it { is_expected.to validate_inclusion_of(:deleted).in_array([true, false]) }
-  end
 end

--- a/spec/requests/categories_request_spec.rb
+++ b/spec/requests/categories_request_spec.rb
@@ -48,13 +48,13 @@ RSpec.describe 'Categories', type: :request do
       it_behaves_like 'API returns json'
       it_behaves_like 'response status code: OK'
       it 'returns two category' do
-        expect(json['categories'].size).to eq 2
+        expect(json['data'].size).to eq 2
 
-        expect(json['categories'][0]['id']).to eq first_category.id
-        expect(json['categories'][0]['name']).to eq first_category.name
+        expect(json['data'][0]['id']).to eq first_category.id
+        expect(json['data'][0]['name']).to eq first_category.name
 
-        expect(json['categories'][1]['id']).to eq second_category.id
-        expect(json['categories'][1]['name']).to eq second_category.name
+        expect(json['data'][1]['id']).to eq second_category.id
+        expect(json['data'][1]['name']).to eq second_category.name
       end
     end
   end

--- a/spec/requests/wishes_request_spec.rb
+++ b/spec/requests/wishes_request_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Wishes', type: :request do
+  before { skip_token_authorization }
+
+  let(:user) { create(:user) }
+  let(:category) { create(:category) }
+
+  # 取得する 2つの wish
+  let!(:first_wish) { create(:wish, user: user, category: category) }
+  let!(:second_wish) { create(:wish, user: user, category: category) }
+  # 異なるカテゴリーの wish
+  let!(:other_category_wish) { create(:wish, user: user, category: create(:category)) }
+  # 異なるユーザの wish
+  let!(:other_user_wish) { create(:wish, user: create(:user), category: category) }
+
+  describe 'GET /users/:uid/wishes?category_id=?' do
+    let(:request) { get "/api/v1/users/#{user.uid}/wishes?category_id=#{category.id}" }
+
+    context 'SUCCESS: #index users wishes' do
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: OK'
+
+      it 'returns: users wishes' do
+        request
+        expect(json['data']).to match(
+          [
+            {
+              'id' => first_wish.id,
+              'user_id' => user.id,
+              'category_id' => category.id,
+              'name' => first_wish.name,
+              'star' => first_wish.star,
+              'status' => first_wish.status,
+              'deleted' => first_wish.deleted
+            },
+            {
+              'id' => second_wish.id,
+              'user_id' => user.id,
+              'category_id' => category.id,
+              'name' => second_wish.name,
+              'star' => second_wish.star,
+              'status' => second_wish.status,
+              'deleted' => second_wish.deleted
+            }
+          ]
+        )
+      end
+    end
+    context 'SUCCESS: #index users wishes (no wish)' do
+      let(:unused_category) { create(:category) }
+      let(:request) { get "/api/v1/users/#{user.uid}/wishes?category_id=#{unused_category.id}" }
+ 
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: OK'
+      it 'returns: no wishes' do
+        request
+        expect(json['data'].size).to eq 0
+      end
+    end
+
+    context 'Errors: user Not Found' do
+      let(:fake_uid) { Faker::Alphanumeric.alpha(number: 10) }
+      let(:request) { get "/api/v1/users/#{fake_uid}/wishes?category_id=#{category.id}" }
+
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: NOT FOUND'
+    end
+  end
+
+  describe 'POST /users/:uid/wishes' do
+    let(:request) { post "/api/v1/users/#{user.uid}/wishes", headers: { ACCEPT: 'application/json' }, as: :json, params: { wish: wish_params } }
+
+    let(:wish_params) do
+      {
+        name: name,
+        star: star,
+        category_id: category_id
+      }
+    end
+
+    let(:name) { Faker::Alphanumeric.alpha(number: 10) }
+    let(:star) { Faker::Number.within(range: 1..5) }
+    let(:category_id) { category.id }
+
+    context 'SUCCESS: create wish' do
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: CREATED'
+      it 'increase total number of wish 1' do
+        expect { request }.to change { Wish.count }.by(1)
+      end
+
+      it 'returns: created wish' do
+        request
+        expect(json['data']).to include(
+          {
+            'user_id' => user.id,
+            'category_id' => category.id,
+            'name' => name,
+            'star' => star,
+            'status' => 'wish',
+            'deleted' => false
+          }
+        )
+      end
+    end
+
+    context 'ERROR: not name in params' do
+      let(:name) { nil }
+
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: BAD REQUEST'
+    end
+
+    context 'ERROR: not star in params' do
+      let(:star) { nil }
+
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: BAD REQUEST'
+    end
+
+    context 'ERROR: category not found' do
+      let(:category_id) { nil }
+
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: NOT FOUND'
+    end
+
+    context 'Errors: user Not Found' do
+      let(:fake_uid) { Faker::Alphanumeric.alpha(number: 10) }
+      let(:request) { post "/api/v1/users/#{fake_uid}/wishes", headers: { ACCEPT: 'application/json' }, as: :json, params: { wish: wish_params } }
+
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: NOT FOUND'
+    end
+  end
+end

--- a/spec/requests/wishes_request_spec.rb
+++ b/spec/requests/wishes_request_spec.rb
@@ -49,10 +49,11 @@ RSpec.describe 'Wishes', type: :request do
         )
       end
     end
+
     context 'SUCCESS: #index users wishes (no wish)' do
       let(:unused_category) { create(:category) }
       let(:request) { get "/api/v1/users/#{user.uid}/wishes?category_id=#{unused_category.id}" }
- 
+
       it_behaves_like 'API returns json'
       it_behaves_like 'response status code: OK'
       it 'returns: no wishes' do


### PR DESCRIPTION
## 概要
* endpoint `/users/:uid/wishes #index #create` を作成
* Serializerにて `attributes -> attribute` の修正
* モデルにおいて以下の修正
→ deleted: false のとき presence: true でエラーが出るため
```diff
-  validates :deleted, inclusion: { in: [true, false] }, presence: true
+  validates :deleted, inclusion: { in: [true, false] }
```
* コントローラーにて以下の書き方に変更
→ categories も 'data' で返すように変更
```ruby
# GET /users/:uid/wishes?category_id=
def index
  user_wishes_by_category = @user.wishes.where(category_id: params[:category_id])
  render json: user_wishes_by_category, each_serializer: WishSerializer, root: 'data'
end
```

## 保留した項目・TODOリスト

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）

