### PR TITLE
endpoint #index /users/:uid/wishes

### DIFF
--- a/app/controllers/api/v1/users/wishes_controller.rb
+++ b/app/controllers/api/v1/users/wishes_controller.rb
@@ -7,10 +7,15 @@ module Api
         before_action :set_user, only: %i[index create]
         before_action :set_category, only: %i[create]
 
-        # GET /users/:uid/wishes?category_id=
+        # GET /users/:uid/wishes
+        # TODO: Serializer を用いて実装する
         def index
-          user_wishes_by_category = @user.wishes.where(category_id: params[:category_id])
-          render json: user_wishes_by_category, each_serializer: WishSerializer, root: 'data'
+          # { "categoryname": [ wish, wish, ], ... }
+          user_wishes = {}
+          Category.all.each do |category|
+            user_wishes[category.name] = @user.wishes.where(category_id: category.id)
+          end
+          render json: { data: user_wishes }, status: :ok
         end
 
         # POST /users/:uid/wishes

--- a/spec/requests/wishes_request_spec.rb
+++ b/spec/requests/wishes_request_spec.rb
@@ -7,17 +7,18 @@ RSpec.describe 'Wishes', type: :request do
 
   let(:user) { create(:user) }
   let(:category) { create(:category) }
+  let(:other_category) { create(:category) }
 
   # 取得する 2つの wish
   let!(:first_wish) { create(:wish, user: user, category: category) }
   let!(:second_wish) { create(:wish, user: user, category: category) }
   # 異なるカテゴリーの wish
-  let!(:other_category_wish) { create(:wish, user: user, category: create(:category)) }
+  let!(:other_category_wish) { create(:wish, user: user, category: other_category) }
   # 異なるユーザの wish
   let!(:other_user_wish) { create(:wish, user: create(:user), category: category) }
 
-  describe 'GET /users/:uid/wishes?category_id=?' do
-    let(:request) { get "/api/v1/users/#{user.uid}/wishes?category_id=#{category.id}" }
+  describe 'GET /users/:uid/wishes' do
+    let(:request) { get "/api/v1/users/#{user.uid}/wishes" }
 
     context 'SUCCESS: #index users wishes' do
       it_behaves_like 'API returns json'
@@ -25,40 +26,25 @@ RSpec.describe 'Wishes', type: :request do
 
       it 'returns: users wishes' do
         request
-        expect(json['data']).to match(
-          [
-            {
-              'id' => first_wish.id,
-              'user_id' => user.id,
-              'category_id' => category.id,
-              'name' => first_wish.name,
-              'star' => first_wish.star,
-              'status' => first_wish.status,
-              'deleted' => first_wish.deleted
-            },
-            {
-              'id' => second_wish.id,
-              'user_id' => user.id,
-              'category_id' => category.id,
-              'name' => second_wish.name,
-              'star' => second_wish.star,
-              'status' => second_wish.status,
-              'deleted' => second_wish.deleted
-            }
-          ]
+        # created_at の確認があるため　最初の 2つだけ確認する
+        expect(json['data'][category.name][0]).to include(
+          'id' => first_wish.id,
+          'user_id' => user.id,
+          'category_id' => category.id,
+          'name' => first_wish.name,
+          'star' => first_wish.star,
+          'status' => first_wish.status,
+          'deleted' => first_wish.deleted
         )
-      end
-    end
-
-    context 'SUCCESS: #index users wishes (no wish)' do
-      let(:unused_category) { create(:category) }
-      let(:request) { get "/api/v1/users/#{user.uid}/wishes?category_id=#{unused_category.id}" }
-
-      it_behaves_like 'API returns json'
-      it_behaves_like 'response status code: OK'
-      it 'returns: no wishes' do
-        request
-        expect(json['data'].size).to eq 0
+        expect(json['data'][other_category.name][0]).to include(
+          'id' => other_category_wish.id,
+          'user_id' => user.id,
+          'category_id' => other_category.id,
+          'name' => other_category_wish.name,
+          'star' => other_category_wish.star,
+          'status' => other_category_wish.status,
+          'deleted' => other_category_wish.deleted
+        )
       end
     end
 


### PR DESCRIPTION
## 概要
エンドポイントの修正 `endpoint #index /users/:uid/wishes` 
これまでカテゴリーごとにリクエストを送っていたが
リクエストの回数が多く処理が重くなっていたため，一度に全てのカテゴリーを分けて返すようにした．

コントローラーで以下のように書いているためリファクタリングの必要あり
→ Serializer も使っていないので修正
```ruby
# { "categoryname": [ wish, wish, ], ... }
user_wishes = {}
Category.all.each do |category|
  user_wishes[category.name] = @user.wishes.where(category_id: category.id)
end
```

## 詳細（主に技術的変更点）

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）

## 保留した項目・TODOリスト

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）

