### PR TITLE
Wish コントローラの修正 （update の実装も）

### DIFF
--- a/app/controllers/api/v1/users/wishes_controller.rb
+++ b/app/controllers/api/v1/users/wishes_controller.rb
@@ -6,6 +6,7 @@ module Api
       class WishesController < ApplicationController
         before_action :set_user, only: %i[index create]
         before_action :set_category, only: %i[create]
+        before_action :set_wish, only: %i[update]
 
         # GET /users/:uid/wishes
         # TODO: Serializer を用いて実装する
@@ -29,6 +30,15 @@ module Api
           end
         end
 
+        # PUT /users/:uid/wishes/:id
+        def update
+          if @wish.update(update_params)
+            render json: { data: WishSerializer.new(@wish) }, status: :ok
+          else
+            render json: { error: "failed to update wish's property", data: @wish.errors }, status: :bad_request
+          end
+        end
+
         private
 
         def set_user
@@ -41,12 +51,21 @@ module Api
           render json: { error: 'category not found' }, status: :not_found unless @category
         end
 
+        def set_wish
+          @wish = Wish.find_by(id: params[:id])
+          render json: { error: 'wish not found' }, status: :not_found unless @wish
+        end
+
         def wish_params
           params.require(:wish).permit(:name, :star)
         end
 
         def category_params
           params.require(:wish).permit(:category_id)
+        end
+
+        def update_params
+          params.require(:wish).permit(:name, :star, :deleted, :status, :category_id)
         end
       end
     end

--- a/app/models/wish.rb
+++ b/app/models/wish.rb
@@ -16,6 +16,6 @@ class Wish < ApplicationRecord
   validates :status, presence: true
 
   validates :deleted, inclusion: { in: [true, false] }
-  # TODO: test
-  default_scope { order(star: :desc) }
+
+  default_scope { order(star: :desc).where(deleted: false) }
 end

--- a/app/models/wish.rb
+++ b/app/models/wish.rb
@@ -16,4 +16,6 @@ class Wish < ApplicationRecord
   validates :status, presence: true
 
   validates :deleted, inclusion: { in: [true, false] }
+  # TODO: test
+  default_scope { order(star: :desc) }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
       # User
       resources :users, param: :uid, only: [:create], controller: 'users' do
         member do #users/:uid
-          resources :wishes, only: [:index, :create], controller: 'users/wishes'
+          resources :wishes, only: [:index, :create, :update], controller: 'users/wishes'
         end
       end
       # Category

--- a/spec/factories/wish.rb
+++ b/spec/factories/wish.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     user { association(:user) }
     category { association(:category) }
     name { Faker::Alphanumeric.alpha(number: 10) }
-    star { Faker::Number.within(range: 1..5) }
+    star { 1 }
     status { 'wish' }
     deleted { false }
   end

--- a/spec/models/wish_spec.rb
+++ b/spec/models/wish_spec.rb
@@ -24,15 +24,15 @@ RSpec.describe Wish, type: :model do
   end
 
   describe 'default_scope: order(star: :desc)' do
-    let!(:wish_1) { create(:wish, star: 1) }
-    let!(:wish_2) { create(:wish, star: 2) }
-    let!(:wish_3) { create(:wish, star: 3) }
+    let!(:wish_one) { create(:wish, star: 1) }
+    let!(:wish_two) { create(:wish, star: 2) }
+    let!(:wish_three) { create(:wish, star: 3) }
 
     it 'order(star: :desc)' do
       wishes = Wish.all
-      expect(wishes[0].id).to eq wish_3.id
-      expect(wishes[1].id).to eq wish_2.id
-      expect(wishes[2].id).to eq wish_1.id
+      expect(wishes[0].id).to eq wish_three.id
+      expect(wishes[1].id).to eq wish_two.id
+      expect(wishes[2].id).to eq wish_one.id
     end
   end
 

--- a/spec/models/wish_spec.rb
+++ b/spec/models/wish_spec.rb
@@ -35,4 +35,15 @@ RSpec.describe Wish, type: :model do
       expect(wishes[2].id).to eq wish_1.id
     end
   end
+
+  describe 'default_scope: where(deleted: false)' do
+    let!(:deleted_wish) { create(:wish, deleted: true) }
+    let!(:not_deleted_wish) { create(:wish, deleted: false) }
+
+    it 'where(deleted: false)' do
+      wishes = Wish.all
+      expect(wishes.size).to eq 1
+      expect(wishes[0].id).to eq not_deleted_wish.id
+    end
+  end
 end

--- a/spec/models/wish_spec.rb
+++ b/spec/models/wish_spec.rb
@@ -22,4 +22,17 @@ RSpec.describe Wish, type: :model do
     it { is_expected.to validate_presence_of(:status) }
     it { is_expected.to define_enum_for(:status).with_values(%i[wish bougth]) }
   end
+
+  describe 'default_scope: order(star: :desc)' do
+    let!(:wish_1) { create(:wish, star: 1) }
+    let!(:wish_2) { create(:wish, star: 2) }
+    let!(:wish_3) { create(:wish, star: 3) }
+
+    it 'order(star: :desc)' do
+      wishes = Wish.all
+      expect(wishes[0].id).to eq wish_3.id
+      expect(wishes[1].id).to eq wish_2.id
+      expect(wishes[2].id).to eq wish_1.id
+    end
+  end
 end

--- a/spec/requests/wishes_request_spec.rb
+++ b/spec/requests/wishes_request_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Wishes', type: :request do
 
     context 'Errors: user Not Found' do
       let(:fake_uid) { Faker::Alphanumeric.alpha(number: 10) }
-      let(:request) { get "/api/v1/users/#{fake_uid}/wishes?category_id=#{category.id}" }
+      let(:request) { get "/api/v1/users/#{fake_uid}/wishes" }
 
       it_behaves_like 'API returns json'
       it_behaves_like 'response status code: NOT FOUND'
@@ -121,6 +121,63 @@ RSpec.describe 'Wishes', type: :request do
 
       it_behaves_like 'API returns json'
       it_behaves_like 'response status code: NOT FOUND'
+    end
+  end
+
+  describe 'PUT /users/:uid/wishes/:id' do
+    let(:request) { put "/api/v1/users/#{user.uid}/wishes/#{first_wish.id}", headers: headers, as: :json, params: wish_params }
+
+    context 'SUCCESS: #update all params' do
+      let(:new_name) { Faker::Alphanumeric.alpha(number: 10) }
+      let(:new_category) { create(:category) }
+      let(:new_star) { Faker::Number.within(range: 1..5) }
+      let(:new_status) { :bougth }
+      let(:new_deleted) { true }
+
+      let(:wish_params) do
+        {
+          wish: {
+            name: new_name,
+            category_id: new_category.id,
+            star: new_star,
+            status: new_status,
+            deleted: new_deleted
+          }
+        }
+      end
+
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: OK'
+
+      it 'returns: updated users wishes' do
+        request
+        expect(json['data']).to match(
+          {
+            'id' => first_wish.id,
+            'user_id' => user.id,
+            'category_id' => new_category.id,
+            'name' => new_name,
+            'star' => new_star,
+            'status' => String(new_status),
+            'deleted' => new_deleted
+          }
+        )
+      end
+    end
+
+    context 'ERROR: #update wrong params' do
+      let(:new_star) { nil }
+
+      let(:wish_params) do
+        {
+          wish: {
+            star: new_star
+          }
+        }
+      end
+
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: BAD REQUEST'
     end
   end
 end


### PR DESCRIPTION
## 概要
* #index で取得する wishes を `star` 順にした [`5400e6c`](https://github.com/shin-shin-01/wishapp_api/commit/5400e6cf92d53f445f89a7e77d997fb9c3c0dac8)
* #index で取得する wishes を `deleted: false` にした [`7027f1d`](https://github.com/shin-shin-01/wishapp_api/pull/20/commits/7027f1deb14c12ed7d131ab2e958b7e31feb6901)
* #update を実装 [`4bd6b`](https://github.com/shin-shin-01/wishapp_api/pull/20/commits/4bd6b786e7239b352d3884493f15b5a95ce23e5f)

## 詳細（主に技術的変更点）

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）

## 保留した項目・TODOリスト

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）

