### PR TITLE
Wish Index更新（ユーザ名・カテゴリ名）

### DIFF
--- a/app/controllers/api/v1/users/wishes_controller.rb
+++ b/app/controllers/api/v1/users/wishes_controller.rb
@@ -9,12 +9,15 @@ module Api
         before_action :set_wish, only: %i[update]
 
         # GET /users/:uid/wishes
-        # TODO: Serializer を用いて実装する
         def index
           # { "categoryname": [ wish, wish, ], ... }
           user_wishes = {}
           Category.all.each do |category|
-            user_wishes[category.name] = @user.wishes.where(category_id: category.id)
+            user_wishes[category.name] = (ActiveModelSerializers::SerializableResource.new(
+              @user.wishes.where(category_id: category.id),
+              each_serializer: WishSerializer,
+              root: category.name
+            ).serializable_hash)[:"#{category.name}"]
           end
           render json: { data: user_wishes }, status: :ok
         end

--- a/app/serializers/wish_serializer.rb
+++ b/app/serializers/wish_serializer.rb
@@ -8,4 +8,11 @@ class WishSerializer < ActiveModel::Serializer
   attribute :star
   attribute :status
   attribute :deleted
+
+  attribute :user_name do
+    object.user.name
+  end
+  attribute :category_name do
+    object.category.name
+  end
 end

--- a/spec/requests/wishes_request_spec.rb
+++ b/spec/requests/wishes_request_spec.rb
@@ -26,24 +26,46 @@ RSpec.describe 'Wishes', type: :request do
 
       it 'returns: users wishes' do
         request
-        # created_at の確認があるため　最初の 2つだけ確認する
-        expect(json['data'][category.name][0]).to include(
-          'id' => first_wish.id,
-          'user_id' => user.id,
-          'category_id' => category.id,
-          'name' => first_wish.name,
-          'star' => first_wish.star,
-          'status' => first_wish.status,
-          'deleted' => first_wish.deleted
-        )
-        expect(json['data'][other_category.name][0]).to include(
-          'id' => other_category_wish.id,
-          'user_id' => user.id,
-          'category_id' => other_category.id,
-          'name' => other_category_wish.name,
-          'star' => other_category_wish.star,
-          'status' => other_category_wish.status,
-          'deleted' => other_category_wish.deleted
+        expect(json['data']).to match(
+          {
+            category.name => [
+              {
+                'id' => first_wish.id,
+                'user_id' => user.id,
+                'user_name' => user.name,
+                'category_id' => category.id,
+                'category_name' => category.name,
+                'name' => first_wish.name,
+                'star' => first_wish.star,
+                'status' => first_wish.status,
+                'deleted' => first_wish.deleted
+              },
+              {
+                'id' => second_wish.id,
+                'user_id' => user.id,
+                'user_name' => user.name,
+                'category_id' => category.id,
+                'category_name' => category.name,
+                'name' => second_wish.name,
+                'star' => second_wish.star,
+                'status' => second_wish.status,
+                'deleted' => second_wish.deleted
+              }
+            ],
+            other_category.name => [
+              {
+                'id' => other_category_wish.id,
+                'user_id' => user.id,
+                'user_name' => user.name,
+                'category_id' => other_category.id,
+                'category_name' => other_category.name,
+                'name' => other_category_wish.name,
+                'star' => other_category_wish.star,
+                'status' => other_category_wish.status,
+                'deleted' => other_category_wish.deleted
+              }
+            ]
+          }
         )
       end
     end
@@ -155,7 +177,9 @@ RSpec.describe 'Wishes', type: :request do
           {
             'id' => first_wish.id,
             'user_id' => user.id,
+            'user_name' => user.name,
             'category_id' => new_category.id,
+            'category_name' => new_category.name,
             'name' => new_name,
             'star' => new_star,
             'status' => String(new_status),


### PR DESCRIPTION
## 概要
Wish の `#index` にて ユーザ名とカテゴリ名を取得するように変更した
処理が重い実装になっているので，良い実装が思いつき次第修正する．

## 保留した項目・TODOリスト
- [ ] リファクタリング

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）

