### PR TITLE
画像 を保存できるようにした

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -40,4 +40,5 @@ jobs:
           RAILS_ENV: github_action
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           AUTHORIZATION_URL: ${{ secrets.AUTHORIZATION_URL }}
+          DEFAULT_IMAGE_URL: ${{ secrets.DEFAULT_IMAGE_URL }}
         run: bundle exec rspec --require rails_helper

--- a/app/controllers/api/v1/users/images_controller.rb
+++ b/app/controllers/api/v1/users/images_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Users
+      class ImagesController < ApplicationController
+        before_action :set_user, only: %i[create]
+        before_action :set_wish, only: %i[create]
+
+        # POST /users/:uid/image
+        def create
+          new_image = Image.new(image_params.merge({ wish: @wish }))
+
+          if new_image.save
+            render json: { data: ImageSerializer.new(new_image) }, status: :created
+          else
+            render json: { error: 'Failed to create new Image', data: new_image.errors }, status: :bad_request
+          end
+        end
+
+        private
+
+        def set_user
+          @user = User.find_by(uid: params[:uid])
+          render json: { error: 'user not found' }, status: :not_found unless @user
+        end
+
+        def set_wish
+          @wish = @user.wishes.find_by(id: wish_params[:id])
+          render json: { error: 'wish not found' }, status: :not_found unless @wish
+        end
+
+        def wish_params
+          params.require(:wish).permit(:id)
+        end
+
+        def image_params
+          params.require(:image).permit(:url)
+        end
+      end
+    end
+  end
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Image < ApplicationRecord
+  belongs_to :wish
+  validates :url, length: { maximum: 255 }, presence: true
+end

--- a/app/models/wish.rb
+++ b/app/models/wish.rb
@@ -3,6 +3,7 @@
 class Wish < ApplicationRecord
   belongs_to :user
   belongs_to :category
+  has_many :images, dependent: :restrict_with_error
 
   validates :name, length: { maximum: 255 }, presence: true
   validates :star,

--- a/app/serializers/friend_wish_serializer.rb
+++ b/app/serializers/friend_wish_serializer.rb
@@ -24,6 +24,6 @@ class FriendWishSerializer < ActiveModel::Serializer
   # TODO: 複数画像に対応
   attribute :image_url do
     latest_image = object.images.last
-    latest_image.nil? ? 'https://firebasestorage.googleapis.com/v0/b/wish-image-ae34c.appspot.com/o/default%2FdefaultNoImage.png?alt=media&token=391f1ff8-14a5-4cce-91ac-16ea751b3462' : latest_image.url
+    latest_image.nil? ? ENV['DEFAULT_IMAGE_URL'] : latest_image.url
   end
 end

--- a/app/serializers/friend_wish_serializer.rb
+++ b/app/serializers/friend_wish_serializer.rb
@@ -19,4 +19,11 @@ class FriendWishSerializer < ActiveModel::Serializer
   attribute :category_name do
     object.category.name
   end
+
+  # 画像がない場合は デフォルト画像
+  # TODO: 複数画像に対応
+  attribute :image_url do
+    latest_image = object.images.last
+    latest_image.nil? ? 'https://firebasestorage.googleapis.com/v0/b/wish-image-ae34c.appspot.com/o/default%2FdefaultNoImage.png?alt=media&token=391f1ff8-14a5-4cce-91ac-16ea751b3462' : latest_image.url
+  end
 end

--- a/app/serializers/image_serializer.rb
+++ b/app/serializers/image_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ImageSerializer < ActiveModel::Serializer
+  attribute :id
+  attribute :wish_id
+  attribute :url
+end

--- a/app/serializers/wish_serializer.rb
+++ b/app/serializers/wish_serializer.rb
@@ -15,4 +15,10 @@ class WishSerializer < ActiveModel::Serializer
   attribute :category_name do
     object.category.name
   end
+  # 画像がない場合は デフォルト画像
+  # TODO: 複数画像に対応
+  attribute :image_url do
+    latest_image = object.images.last
+    latest_image.nil? ? 'https://firebasestorage.googleapis.com/v0/b/wish-image-ae34c.appspot.com/o/default%2FdefaultNoImage.png?alt=media&token=391f1ff8-14a5-4cce-91ac-16ea751b3462' : latest_image.url
+  end
 end

--- a/app/serializers/wish_serializer.rb
+++ b/app/serializers/wish_serializer.rb
@@ -19,6 +19,6 @@ class WishSerializer < ActiveModel::Serializer
   # TODO: 複数画像に対応
   attribute :image_url do
     latest_image = object.images.last
-    latest_image.nil? ? 'https://firebasestorage.googleapis.com/v0/b/wish-image-ae34c.appspot.com/o/default%2FdefaultNoImage.png?alt=media&token=391f1ff8-14a5-4cce-91ac-16ea751b3462' : latest_image.url
+    latest_image.nil? ? ENV['DEFAULT_IMAGE_URL'] : latest_image.url
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
           resources :wishes, only: [:index, :create, :update], controller: 'users/wishes'
           resources :friends, only: [:index, :create], controller: 'users/friends'
           resources :friend_wishes, only: [:index], controller: 'users/friend_wishes'
+          resources :images, only: [:create], controller: 'users/images'
         end
       end
       # Category

--- a/db/migrate/20210317160018_create_images.rb
+++ b/db/migrate/20210317160018_create_images.rb
@@ -1,0 +1,10 @@
+class CreateImages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :images do |t|
+      t.references :wish, null: false, foreign_key: true
+      t.string :url, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_25_160018) do
+ActiveRecord::Schema.define(version: 2021_03_17_160018) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "name", null: false
@@ -27,6 +27,14 @@ ActiveRecord::Schema.define(version: 2021_02_25_160018) do
     t.index ["friend_user_id"], name: "index_friends_on_friend_user_id"
     t.index ["user_id", "friend_user_id"], name: "index_friends_on_user_id_and_friend_user_id", unique: true
     t.index ["user_id"], name: "index_friends_on_user_id"
+  end
+
+  create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
+    t.bigint "wish_id", null: false
+    t.string "url", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["wish_id"], name: "index_images_on_wish_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
@@ -55,6 +63,7 @@ ActiveRecord::Schema.define(version: 2021_02_25_160018) do
 
   add_foreign_key "friends", "Users", column: "friend_user_id"
   add_foreign_key "friends", "Users", column: "user_id"
+  add_foreign_key "images", "wishes"
   add_foreign_key "wishes", "categories"
   add_foreign_key "wishes", "users"
 end

--- a/spec/factories/image.rb
+++ b/spec/factories/image.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :image do
+    wish { association(:wish) }
+    url { Faker::Alphanumeric.alpha(number: 10) }
+  end
+end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Image, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:wish) }
+  end
+
+  describe 'validation: url' do
+    it { is_expected.to validate_length_of(:url).is_at_most(255) }
+    it { is_expected.to validate_presence_of(:url) }
+  end
+end

--- a/spec/models/wish_spec.rb
+++ b/spec/models/wish_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Wish, type: :model do
   describe 'associations' do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:category) }
+    it { is_expected.to have_many(:images) }
   end
 
   describe 'validation: name' do

--- a/spec/requests/friend_wishes_request_spec.rb
+++ b/spec/requests/friend_wishes_request_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe 'FriendWishes', type: :request do
   let(:first_friend_user) { create(:user) }
   let(:second_friend_user) { create(:user) }
 
+  # wish の画像
+  let!(:first_wish_image) { create(:image, wish: first_wish) }
+  let!(:second_wish_image) { create(:image, wish: second_wish) }
+  let!(:second_category_wish_image) { create(:image, wish: second_category_wish) }
+  let!(:user_wish_image) { create(:image, wish: user_wish) }
+
   describe 'GET /users/:uid/friend_wishes' do
     let(:request) { get "/api/v1/users/#{user.uid}/friend_wishes" }
 
@@ -46,7 +52,8 @@ RSpec.describe 'FriendWishes', type: :request do
                 'name' => first_wish.name,
                 'star' => first_wish.star,
                 'status' => first_wish.status,
-                'deleted' => first_wish.deleted
+                'deleted' => first_wish.deleted,
+                'image_url' => first_wish_image.url
               },
               {
                 'id' => second_wish.id,
@@ -58,7 +65,8 @@ RSpec.describe 'FriendWishes', type: :request do
                 'name' => second_wish.name,
                 'star' => second_wish.star,
                 'status' => second_wish.status,
-                'deleted' => second_wish.deleted
+                'deleted' => second_wish.deleted,
+                'image_url' => second_wish_image.url
               }
             ],
             second_category.name => [
@@ -72,7 +80,8 @@ RSpec.describe 'FriendWishes', type: :request do
                 'name' => second_category_wish.name,
                 'star' => second_category_wish.star,
                 'status' => second_category_wish.status,
-                'deleted' => second_category_wish.deleted
+                'deleted' => second_category_wish.deleted,
+                'image_url' => second_category_wish_image.url
               }
             ]
           }

--- a/spec/requests/images_request_spec.rb
+++ b/spec/requests/images_request_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Images', type: :request do
+  before { skip_token_authorization }
+
+  let(:user) { create(:user) }
+  let(:wish) { create(:wish, user: user) }
+
+  describe 'POST /users/:uid/images' do
+    let(:request) { post "/api/v1/users/#{user.uid}/images", headers: { ACCEPT: 'application/json' }, as: :json, params: { wish: wish_params, image: image_params } }
+
+    let(:wish_params) { { id: wish.id } }
+    let(:image_params) { { url: url } }
+
+    let(:url) { Faker::Alphanumeric.alpha(number: 10) }
+
+    context 'SUCCESS: create image' do
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: CREATED'
+      it 'increase total number of image 1' do
+        expect { request }.to change { Image.count }.by(1)
+      end
+
+      it 'returns: created image' do
+        request
+        expect(json['data']).to include(
+          {
+            'wish_id' => wish.id,
+            'url' => url
+          }
+        )
+      end
+    end
+
+    context 'ERROR: not url in params' do
+      let(:url) { nil }
+
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: BAD REQUEST'
+    end
+
+    context 'ERROR: wish not found' do
+      let(:wish_params) { { id: wish.id + 100 } }
+
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: NOT FOUND'
+    end
+
+    context 'Errors: user Not Found' do
+      let(:fake_uid) { Faker::Alphanumeric.alpha(number: 10) }
+      let(:request) { post "/api/v1/users/#{fake_uid}/wishes", headers: { ACCEPT: 'application/json' }, as: :json, params: { wish: wish_params } }
+
+      it_behaves_like 'API returns json'
+      it_behaves_like 'response status code: NOT FOUND'
+    end
+  end
+end

--- a/spec/requests/wishes_request_spec.rb
+++ b/spec/requests/wishes_request_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe 'Wishes', type: :request do
   # 異なるユーザの wish
   let!(:other_user_wish) { create(:wish, user: create(:user), category: category) }
 
+  # wish の画像
+  let!(:first_wish_image) { create(:image, wish: first_wish) }
+  let!(:second_wish_image) { create(:image, wish: second_wish) }
+  let!(:other_category_wish_image) { create(:image, wish: other_category_wish) }
+  let!(:other_user_wish_image) { create(:image, wish: other_user_wish) }
+
   describe 'GET /users/:uid/wishes' do
     let(:request) { get "/api/v1/users/#{user.uid}/wishes" }
 
@@ -38,7 +44,8 @@ RSpec.describe 'Wishes', type: :request do
                 'name' => first_wish.name,
                 'star' => first_wish.star,
                 'status' => first_wish.status,
-                'deleted' => first_wish.deleted
+                'deleted' => first_wish.deleted,
+                'image_url' => first_wish_image.url
               },
               {
                 'id' => second_wish.id,
@@ -49,7 +56,8 @@ RSpec.describe 'Wishes', type: :request do
                 'name' => second_wish.name,
                 'star' => second_wish.star,
                 'status' => second_wish.status,
-                'deleted' => second_wish.deleted
+                'deleted' => second_wish.deleted,
+                'image_url' => second_wish_image.url
               }
             ],
             other_category.name => [
@@ -62,7 +70,8 @@ RSpec.describe 'Wishes', type: :request do
                 'name' => other_category_wish.name,
                 'star' => other_category_wish.star,
                 'status' => other_category_wish.status,
-                'deleted' => other_category_wish.deleted
+                'deleted' => other_category_wish.deleted,
+                'image_url' => other_category_wish_image.url
               }
             ]
           }
@@ -110,7 +119,8 @@ RSpec.describe 'Wishes', type: :request do
             'name' => name,
             'star' => star,
             'status' => 'wish',
-            'deleted' => false
+            'deleted' => false,
+            'image_url' => "https://firebasestorage.googleapis.com/v0/b/wish-image-ae34c.appspot.com/o/default%2FdefaultNoImage.png?alt=media&token=391f1ff8-14a5-4cce-91ac-16ea751b3462"
           }
         )
       end
@@ -183,7 +193,8 @@ RSpec.describe 'Wishes', type: :request do
             'name' => new_name,
             'star' => new_star,
             'status' => String(new_status),
-            'deleted' => new_deleted
+            'deleted' => new_deleted,
+            'image_url' => first_wish_image.url
           }
         )
       end

--- a/spec/requests/wishes_request_spec.rb
+++ b/spec/requests/wishes_request_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe 'Wishes', type: :request do
             'star' => star,
             'status' => 'wish',
             'deleted' => false,
-            'image_url' => "https://firebasestorage.googleapis.com/v0/b/wish-image-ae34c.appspot.com/o/default%2FdefaultNoImage.png?alt=media&token=391f1ff8-14a5-4cce-91ac-16ea751b3462"
+            'image_url' => ENV['DEFAULT_IMAGE_URL']
           }
         )
       end


### PR DESCRIPTION
## 概要
* Image テーブルの作成
* Image コントローラー（Create の作成）

WishSerializer で 最新の `image_url` 　を返すようにした
→ 将来的には 複数の URL 返して，アプリ側でスライド形式で表示する．

## 詳細（主に技術的変更点）

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）

## 保留した項目・TODOリスト
- [ ] 複数画像に対応（削除カラムの追加）

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）

